### PR TITLE
Fixed starting a new free-form selection while a previous one

### DIFF
--- a/src/tools.js
+++ b/src/tools.js
@@ -22,11 +22,12 @@ tools = [{
 		tool.y_max = pointer.y+1;
 		tool.points = [];
 		
-		if(selection){
-			selection.draw();
-			selection.destroy();
-			selection = null;
-		}
+    // End prior selection, drawing it to the canvas
+    deselect();
+    // Checkpoint so we can roll back inverty brush
+    // @TODO Still probably need to use something other than the undo stack
+    undoable();
+
 		// The inverty brush is continuous in space which means
 		// paint(ctx, x, y) will be called for each pixel the pointer moves
 		// and we only need to record individual pointer events to make the polygon
@@ -66,10 +67,6 @@ tools = [{
 		var rect_w = inverty_size;
 		var rect_h = inverty_size;
 		
-		// @TODO @FIXME get rid of this part:
-		if(!undos.length){
-			undoable();//ugh... this is supposed to be passive
-		}//phhh
 		var ctx_src = undos[undos.length-1].getContext("2d");//psh
 		
 		// Make two tiny ImageData objects,

--- a/src/tools.js
+++ b/src/tools.js
@@ -22,11 +22,11 @@ tools = [{
 		tool.y_max = pointer.y+1;
 		tool.points = [];
 		
-    // End prior selection, drawing it to the canvas
-    deselect();
-    // Checkpoint so we can roll back inverty brush
-    // @TODO Still probably need to use something other than the undo stack
-    undoable();
+		// End prior selection, drawing it to the canvas
+		deselect();
+		// Checkpoint so we can roll back inverty brush
+		// @TODO Still probably need to use something other than the undo stack
+		undoable();
 
 		// The inverty brush is continuous in space which means
 		// paint(ctx, x, y) will be called for each pixel the pointer moves


### PR DESCRIPTION
already exists deletes the prior selection. This should address issue #3, I was able to reproduce the issue on Chrome 51/OSX.

The issue seems the be the logic on what was previously line 70, `undos` can be non-empty on the first mouse-move event so the state we roll back to in pointerup (to undo inverty brush) won't have the translated selection in it.