### PR TITLE
Don't use anti-aliasing for sketch/skew

### DIFF
--- a/src/image-manipulation.js
+++ b/src/image-manipulation.js
@@ -451,6 +451,10 @@ function stretch_and_skew(xscale, yscale, hsa, vsa){
 		}
 		
 		new_ctx.save();
+
+		// do a "nearest-neighbor" resize to keep pixelated edges
+		new_ctx.imageSmoothingEnabled = false;
+
 		new_ctx.transform(
 			1, // x scale
 			Math.tan(vsa), // vertical skew (skewY)


### PR DESCRIPTION
Resizes shouldn't use anti-aliasing (verified on https://copy.sh/v86/?profile=windows98)

| win98 before resize | pixelated after resize|
|---|---|
| <img width="397" alt="screen shot 2018-01-18 at 3 47 09 pm" src="https://user-images.githubusercontent.com/116838/35123301-4db0dec6-fc67-11e7-805b-e5edd476d833.png"> | <img width="388" alt="screen shot 2018-01-18 at 3 47 23 pm" src="https://user-images.githubusercontent.com/116838/35123302-4dcf44ba-fc67-11e7-800c-85b9f9b6b59a.png"> |

jspaint applies anti-aliasing on resize, so this PR fixes that:

| jspaint before resize | ❌ blurry after resize | ✅  pixelated after resize |
|---|---|---|
| <img width="372" alt="screen shot 2018-01-18 at 3 52 52 pm" src="https://user-images.githubusercontent.com/116838/35123444-d1b0e4c8-fc67-11e7-8789-ca0f4543a365.png"> | <img width="434" alt="screen shot 2018-01-18 at 3 53 01 pm" src="https://user-images.githubusercontent.com/116838/35123445-d1c0ac28-fc67-11e7-8c4a-209d39ad7718.png"> | <img width="442" alt="screen shot 2018-01-18 at 3 53 36 pm" src="https://user-images.githubusercontent.com/116838/35123503-0da58394-fc68-11e7-9e14-8b237cd599d8.png"> |
