### PR TITLE
Firefox Zoom Blur Fix 

### DIFF
--- a/styles/themes/classic.css
+++ b/styles/themes/classic.css
@@ -16,6 +16,7 @@
 * {
 	image-rendering: crisp-edges;
 	image-rendering: pixelated;
+	image-rendering: -moz-crisp-edges;
 }
 .selection:after,
 .textbox:after {

--- a/styles/themes/modern.css
+++ b/styles/themes/modern.css
@@ -16,6 +16,7 @@ body {
 .selection img {
 	image-rendering: crisp-edges;
 	image-rendering: pixelated;
+	image-rendering: -moz-crisp-edges;
 }
 
 .selection:after,


### PR DESCRIPTION
Fixes issue #46 by adding `image-rendering: -moz-crisp-edges` the syntax for Firefox crisp edge rendering.

## Result 
![jspaint result](https://user-images.githubusercontent.com/27080760/35186279-a890deda-fddf-11e7-93a1-29759ae0cfcf.gif)

