### PR TITLE
Adds paste selection with ctl+left click

### DIFF
--- a/src/Selection.js
+++ b/src/Selection.js
@@ -107,6 +107,9 @@ Selection.prototype.instantiate = function(_img, _passive){
 			if(e.shiftKey){
 				sel.draw();
 			}
+			else if(e.ctrlKey){
+				sel.draw();
+			}   
 		};
 		
 		$(sel.canvas).on("pointerdown", sel.canvas_pointerdown);


### PR DESCRIPTION
Adds enhancement #32 by checking if control is pressed in `sel.canvas_pointerdown = function(e)` and if so executing `sel.draw()`

## Result 

![selection paste](https://user-images.githubusercontent.com/27080760/35190534-f683dffa-fe31-11e7-87cd-2ce29517db71.gif)

**Note**: When the user holds ctrl and left clicks the image is pasted and keeps the selection allowing multiple pastes