### PR TITLE
Fix external links in Chrome App

### DIFF
--- a/chrome-app.js
+++ b/chrome-app.js
@@ -12,6 +12,14 @@ chrome.app.runtime.onLaunched.addListener(function(launch_data) {
 		},
 		function(window) {
 			window.contentWindow.file_entry = entry;
+
+			window.contentWindow.document.addEventListener('click', function(event) {
+				let anchor = event.target;
+
+				if (is_anchor(anchor) && is_external_link(anchor.href)) {
+					set_anchor_target_to_open_new_tab(anchor);
+				}
+			});
 		});
 	}
 
@@ -21,3 +29,26 @@ chrome.app.runtime.onLaunched.addListener(function(launch_data) {
 		open_image();
 	}
 });
+
+/**
+ * @param {HTMLElement} anchor
+ * @return string
+ */
+function is_anchor(anchor) {
+	return anchor.nodeName === 'A';
+}
+
+/**
+ * @param {string} href
+ * @return {boolean}
+ */
+function is_external_link(href) {
+	return href.match(/(http|https):\/\//);
+}
+
+/**
+ * @param {HTMLElement} anchor
+ */
+function set_anchor_target_to_open_new_tab(anchor) {
+	anchor.target = '_blank';
+}


### PR DESCRIPTION
Based on the discussion from #69:

- Force external links in Chrome App to be opened in a new tab

Setting the link targets to `_blank` (for the Chrome Packaged App instance only) was done because the [`chrome.tabs`](https://developer.chrome.com/extensions/tabs) API is available [only to Hosted Apps and Extensions](https://stackoverflow.com/a/14342897). No matter what permissions you enable for the Packaged App, `chrome.tabs` will remain undefined.

This approach seems to achieve the desired affect, however.