### PR TITLE
Prevent key input when dialog window is open

### DIFF
--- a/src/$Window.js
+++ b/src/$Window.js
@@ -173,12 +173,15 @@ function $Window($component){
 		}
 		$w.remove();
 		$w.closed = true;
+		dialogOpen = false;
 	};
 	$w.closed = false;
 	
 	if(!$component){
 		$w.center();
 	}
+	
+	dialogOpen = true;
 	
 	return $w;
 }

--- a/src/app.js
+++ b/src/app.js
@@ -41,6 +41,7 @@ var font = {
 	size: 12,
 	line_scale: 20 / 12
 };
+var dialogOpen = false; // Will prevent key shortcuts if true
 
 var undos = []; //array of <canvas>
 var redos = []; //array of <canvas>
@@ -170,7 +171,7 @@ $G.on("keyup", function(e){
 	delete keys[e.keyCode];
 });
 $G.on("keydown", function(e){
-	if(e.isDefaultPrevented()){
+	if((e.isDefaultPrevented()) || (dialogOpen)){
 		return;
 	}
 	if(

--- a/src/app.js
+++ b/src/app.js
@@ -171,6 +171,7 @@ $G.on("keyup", function(e){
 	delete keys[e.keyCode];
 });
 $G.on("keydown", function(e){
+	// If there is an open dialog, ignore key inputs to prevent interference
 	if((e.isDefaultPrevented()) || (dialogOpen)){
 		return;
 	}


### PR DESCRIPTION
This addresses issue #89 where key inputs (the Enter key) effect the selection in addition to the window dialog. To solve this, a boolean was created; it is set to true when a dialog is opened and false when the dialog is closed. Upon entering the key event function in app.js, the value of this boolean is checked; if true, the function returns without performing any key actions. If false, the key handling operations continue as usual.