### PR TITLE
Fix quick undo for mouse.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -485,7 +485,7 @@ function canvas_pointer_move(e){
 				}
 				break;
 			case "touch":
-				// TODO: Handle touch events.
+				// Handled by pointerdown event listener.
 				break;
 			default:
 				// Unknown devices are handled as mouse

--- a/src/app.js
+++ b/src/app.js
@@ -397,7 +397,7 @@ $G.on("cut copy paste", function(e){
 	}
 });
 
-var pointer, pointer_start, pointer_previous;
+var pointer, pointer_start, pointer_previous, pointer_type;
 var reverse, ctrl, button;
 function e2c(e){
 	var rect = canvas.getBoundingClientRect();
@@ -467,6 +467,35 @@ function canvas_pointer_move(e){
 	ctrl = e.ctrlKey;
 	shift = e.shiftKey;
 	pointer = e2c(e);
+	if(pointer_was_pressed && e.button != -1){
+		if(e.pointerType != pointer_type){
+			// Different input devices
+			pointer_was_pressed = false;
+			cancel();
+			return;
+		}
+		switch(pointer_type){
+			case "pen":
+				// TODO: Handle pen events.
+				// Pen cancel button
+				if(e.buttons & 32){
+					pointer_was_pressed = false;
+					cancel();
+					return;
+				}
+				break;
+			case "touch":
+				// TODO: Handle touch events.
+				break;
+			default:
+				// Unknown devices are handled as mouse
+				if((e.buttons & 3) === 3){
+					pointer_was_pressed = false;
+					cancel();
+					return;
+				}
+		}
+	}
 	if(e.shiftKey){
 		if(selected_tool.name.match(/Line|Curve/)){
 			// snap to eight directions
@@ -517,6 +546,7 @@ $canvas.on("pointerdown", function(e){
 		return;
 	}
 	pointer_was_pressed = true;
+	pointer_type = e.pointerType;
 	$G.one("pointerup", function(e){
 		pointer_was_pressed = false;
 	});


### PR DESCRIPTION
Fixes L+R undo for mouse inputs. 
Only input method that does not fully works with quick undo is pen.
Based on [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#Determining_button_states), pen devices should send `mousemove` with `buttons` mask containing `32` when pressing cancel button, which I was unable to reproduce. Maybe it was my driver issues or something else (One by Wacom). It does work properly if I disable Windows Ink mode, but that's due to pen acting as a mouse device.
Tested both on Chrome and Firefox, as well as Chrome for Android.