### PR TITLE
Add NativeFS support

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
 		<script src="src/sessions.js"></script>
 		<script src="lib/konami.js"></script>
 		<script src="src/vaporwave-fun.js"></script>
+		<script type="module" src="src/nativefs.js"></script>
 
 		<script>
 			// Partial support for IE with a general polyfill

--- a/src/functions.js
+++ b/src/functions.js
@@ -186,6 +186,14 @@ function file_new(){
 // there's this little thing called Inversion of Control...
 // also paste_from_file_select_dialog
 function file_open(){
+	if (window.systemOpenFile) {
+		return window.systemOpenFile(function(file){
+			open_from_File(file, function(err){
+				if(err){ return show_error_message("Failed to open file:", err); }
+			});
+		});
+	}
+
 	get_FileList_from_file_select_dialog(function(files){
 		open_from_FileList(files, "selected");
 	});

--- a/src/nativefs.js
+++ b/src/nativefs.js
@@ -1,0 +1,61 @@
+if ('chooseFileSystemEntries' in window) {
+    const acceptedFormats = [{
+        description: 'PNG',
+        extensions: ['png'],
+        mediaTypes: ['image/png']
+    }, {
+        description: 'JPEG',
+        extensions: ['jpg', 'jpeg', 'jpe', 'jfif'],
+        mediaTypes: ['image/jpeg']
+    }, {
+        description: 'WebP',
+        extensions: ['webp'],
+        mediaTypes: ['image/webp']
+    }];
+
+    async function resolveMimeType(fileName) {
+        const extension = fileName.split('.').pop();
+        const format = acceptedFormats.find(format => format.extensions.includes(extension.toLowerCase()));
+        return format && format.mediaTypes[0] || 'image/png';
+    }
+
+    async function saveViaNativeFs(handle, canvas) {
+        const writer = await handle.createWriter();
+
+        const mimeType = resolveMimeType(handle.name);
+        const blob = await new Promise(resolve => canvas.toBlob(resolve, mimeType));
+        const buffer = await blob.arrayBuffer();
+
+        await writer.truncate(0);
+        await writer.write(0, buffer);
+        await writer.close();
+    }
+
+    window.save_to_file_path = async (handle, format, callback) => {
+        await saveViaNativeFs(handle, canvas);
+        callback(handle, handle.name);
+    };
+
+    window.systemOpenFile = async callback => {
+        const handle = await window.chooseFileSystemEntries({
+            accepts: acceptedFormats
+        });
+        const file = await handle.getFile();
+
+        // Caller stores the handle in document_file_path for saving the file later on
+        Object.defineProperty(file, 'path', { value: handle });
+
+        callback(file);
+    };
+
+    window.systemSaveCanvasAs = async (canvas, fileName, savedCallbackUnreliable) => {
+        // TODO: NativeFS currently doesn’t allow suggesting file names.
+        const handle = await window.chooseFileSystemEntries({
+            type: 'saveFile',
+            accepts: acceptedFormats
+        });
+        await saveViaNativeFs(handle, canvas);
+
+        savedCallbackUnreliable(handle, handle.name);
+    };
+}


### PR DESCRIPTION
This PR introduces [support for the Native File System API](https://developers.google.com/web/updates/2019/08/native-file-system), currently experimented with by Chrome. The API isn’t generally available yet, so for testing it you would either have to enable the flag or [request an Origin Trial token](https://developers.google.com/web/updates/2019/08/native-file-system#origin-trial).

The new script makes use of ES6 language features. Using `<script type="module">` prevents the script from being loaded in non-ES6 browsers, which won’t support NativeFS anyway. Using this method, we can progressively enhance the codebase.