### PR TITLE
Add Service Worker by Workbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
 		<script src="src/sessions.js"></script>
 		<script src="lib/konami.js"></script>
 		<script src="src/vaporwave-fun.js"></script>
+		<script type="module" src="src/service-worker.js"></script>
 
 		<script>
 			// Partial support for IE with a general polyfill

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,15 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+      "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@electron-forge/async-ora": {
       "version": "6.0.0-beta.45",
       "resolved": "https://registry.npmjs.org/@electron-forge/async-ora/-/async-ora-6.0.0-beta.45.tgz",
@@ -749,6 +758,45 @@
         }
       }
     },
+    "@hapi/address": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+      "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==",
+      "dev": true
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
+    "@hapi/hoek": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.5.tgz",
+      "integrity": "sha512-rmGFzok1zR3xZKd5m3ihWdqafXFxvPHoQ/78+AG5URKbEbJiwBBfRgzbu+07W5f3+07JRshw6QqGbVmCp8ntig==",
+      "dev": true
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.4.tgz",
+      "integrity": "sha512-aVWQTOI9wBD6zawmOr6f+tdEIxQC8JXfQVLTjgGe8YEStAWGn/GNNVTobKJhbWKveQj2RyYF3oYbO9SC8/eOCA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -853,6 +901,48 @@
         }
       }
     },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -953,16 +1043,34 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asar": {
@@ -1044,6 +1152,26 @@
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
+    "async-done": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+      "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.2",
+        "process-nextick-args": "^2.0.0",
+        "stream-exhaust": "^1.0.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "dev": true
+        }
+      }
+    },
     "async-each": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
@@ -1078,6 +1206,55 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
+    },
+    "babel-extract-comments": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+      "integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
+      "dev": true,
+      "requires": {
+        "babylon": "^6.18.0"
+      }
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "balanced-match": {
@@ -1196,6 +1373,60 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
       "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
+    },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -1359,6 +1590,12 @@
         "node-pre-gyp": "^0.11.0"
       }
     },
+    "capture-stack-trace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1420,6 +1657,12 @@
       "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
       "dev": true
     },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -1442,6 +1685,12 @@
           }
         }
       }
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -1552,6 +1801,12 @@
       "integrity": "sha512-UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ==",
       "dev": true
     },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
+    },
     "compare-version": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
@@ -1580,6 +1835,20 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "configstore": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "connect": {
@@ -1617,6 +1886,12 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1638,6 +1913,15 @@
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
       "dev": true
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "^1.0.0"
+      }
     },
     "cross-spawn": {
       "version": "7.0.0",
@@ -1714,6 +1998,12 @@
         }
       }
     },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
     "cuint": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
@@ -1751,6 +2041,16 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -1883,6 +2183,15 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer": {
@@ -2073,6 +2382,7 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -3398,6 +3708,15 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
+    "for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3493,7 +3812,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3514,12 +3834,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3534,17 +3856,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3661,7 +3986,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3673,6 +3999,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3687,6 +4014,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3694,12 +4022,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3718,6 +4048,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3798,7 +4129,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3810,6 +4142,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3895,7 +4228,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3931,6 +4265,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3950,6 +4285,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3993,12 +4329,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4121,6 +4459,12 @@
       "requires": {
         "global-modules": "1.0.0"
       }
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+      "dev": true
     },
     "get-package-info": {
       "version": "1.0.0",
@@ -4296,6 +4640,29 @@
             "is-extglob": "^2.1.0"
           }
         }
+      }
+    },
+    "glob-watcher": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+      "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-done": "^1.2.0",
+        "chokidar": "^2.0.0",
+        "is-negated-glob": "^1.0.0",
+        "just-debounce": "^1.0.0",
+        "object.defaults": "^1.1.0"
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
       }
     },
     "global-modules": {
@@ -4610,6 +4977,12 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4801,6 +5174,15 @@
         "builtin-modules": "^1.0.0"
       }
     },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.5.0"
+      }
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -4879,6 +5261,28 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-negated-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+      "dev": true
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -4899,6 +5303,27 @@
         }
       }
     },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -4912,6 +5337,24 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
     "is-stream": {
@@ -5005,6 +5448,12 @@
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -5055,6 +5504,12 @@
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
       "dev": true
     },
+    "just-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+      "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+      "dev": true
+    },
     "kew": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
@@ -5095,6 +5550,15 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "^4.0.0"
       }
     },
     "levn": {
@@ -5266,6 +5730,23 @@
         "yallist": "^2.1.2"
       }
     },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -5415,6 +5896,16 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
     },
     "minipass": {
       "version": "2.3.5",
@@ -5850,6 +6341,18 @@
         "isobject": "^3.0.0"
       }
     },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
+      "requires": {
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -6034,6 +6537,60 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        }
+      }
+    },
     "parallelshell": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/parallelshell/-/parallelshell-3.0.2.tgz",
@@ -6110,6 +6667,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -6360,6 +6923,12 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
+    },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -6449,6 +7018,12 @@
         "strip-indent": "^1.0.1"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6464,6 +7039,25 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "registry-auth-token": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.0.1"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -6727,6 +7321,15 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
       "dev": true
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.0.3"
+      }
     },
     "send": {
       "version": "0.16.2",
@@ -7150,6 +7753,12 @@
         "duplexer": "~0.1.1"
       }
     },
+    "stream-exhaust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+      "dev": true
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7187,6 +7796,17 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -7203,6 +7823,16 @@
       "dev": true,
       "requires": {
         "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-comments": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
+      "integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
+      "dev": true,
+      "requires": {
+        "babel-extract-comments": "^1.0.0",
+        "babel-plugin-transform-object-rest-spread": "^6.26.0"
       }
     },
     "strip-eof": {
@@ -7354,6 +7984,49 @@
         "rimraf": "~2.6.2"
       }
     },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7407,6 +8080,12 @@
           "dev": true
         }
       }
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
     },
     "tiny-each-async": {
       "version": "2.0.3",
@@ -7612,6 +8291,15 @@
         "set-value": "^2.0.1"
       }
     },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -7670,11 +8358,35 @@
         }
       }
     },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
+    },
     "upath": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
       "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
       "dev": true
+    },
+    "update-notifier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "dev": true,
+      "requires": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
     },
     "uri-js": {
       "version": "4.2.2",
@@ -7839,6 +8551,48 @@
         "string-width": "^1.0.2 || 2"
       }
     },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -7851,6 +8605,508 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
+    },
+    "workbox-background-sync": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz",
+      "integrity": "sha512-1uFkvU8JXi7L7fCHVBEEnc3asPpiAL33kO495UMcD5+arew9IbKW2rV5lpzhoWcm/qhGB89YfO4PmB/0hQwPRg==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-broadcast-update": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz",
+      "integrity": "sha512-MTSfgzIljpKLTBPROo4IpKjESD86pPFlZwlvVG32Kb70hW+aob4Jxpblud8EhNb1/L5m43DUM4q7C+W6eQMMbA==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-build": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.3.1.tgz",
+      "integrity": "sha512-UHdwrN3FrDvicM3AqJS/J07X0KXj67R8Cg0waq1MKEOqzo89ap6zh6LmaLnRAjpB+bDIz+7OlPye9iii9KBnxw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.4",
+        "@hapi/joi": "^15.0.0",
+        "common-tags": "^1.8.0",
+        "fs-extra": "^4.0.2",
+        "glob": "^7.1.3",
+        "lodash.template": "^4.4.0",
+        "pretty-bytes": "^5.1.0",
+        "stringify-object": "^3.3.0",
+        "strip-comments": "^1.0.2",
+        "workbox-background-sync": "^4.3.1",
+        "workbox-broadcast-update": "^4.3.1",
+        "workbox-cacheable-response": "^4.3.1",
+        "workbox-core": "^4.3.1",
+        "workbox-expiration": "^4.3.1",
+        "workbox-google-analytics": "^4.3.1",
+        "workbox-navigation-preload": "^4.3.1",
+        "workbox-precaching": "^4.3.1",
+        "workbox-range-requests": "^4.3.1",
+        "workbox-routing": "^4.3.1",
+        "workbox-strategies": "^4.3.1",
+        "workbox-streams": "^4.3.1",
+        "workbox-sw": "^4.3.1",
+        "workbox-window": "^4.3.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "pretty-bytes": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+          "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+          "dev": true
+        }
+      }
+    },
+    "workbox-cacheable-response": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz",
+      "integrity": "sha512-Rp5qlzm6z8IOvnQNkCdO9qrDgDpoPNguovs0H8C+wswLuPgSzSp9p2afb5maUt9R1uTIwOXrVQMmPfPypv+npw==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-cli": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-cli/-/workbox-cli-4.3.1.tgz",
+      "integrity": "sha512-2qkAVvqU40d40UES7jMx+vAeLMMjrzc6DO1g98z1bIjA53q1qyzF97SY8xMY/+WnGTO9l6/c/Jk8OdFCih3dsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "chalk": "^2.4.1",
+        "common-tags": "^1.8.0",
+        "fs-extra": "^7.0.0",
+        "glob": "^7.1.3",
+        "glob-watcher": "^5.0.3",
+        "inquirer": "^6.2.0",
+        "meow": "^5.0.0",
+        "ora": "^3.0.0",
+        "pretty-bytes": "^5.1.0",
+        "update-notifier": "^2.5.0",
+        "workbox-build": "^4.3.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+          "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.12",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+          "dev": true
+        },
+        "meow": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+          "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0",
+            "yargs-parser": "^10.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "pretty-bytes": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+          "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "dev": true,
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
+    "workbox-core": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.3.1.tgz",
+      "integrity": "sha512-I3C9jlLmMKPxAC1t0ExCq+QoAMd0vAAHULEgRZ7kieCdUd919n53WC0AfvokHNwqRhGn+tIIj7vcb5duCjs2Kg==",
+      "dev": true
+    },
+    "workbox-expiration": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-4.3.1.tgz",
+      "integrity": "sha512-vsJLhgQsQouv9m0rpbXubT5jw0jMQdjpkum0uT+d9tTwhXcEZks7qLfQ9dGSaufTD2eimxbUOJfWLbNQpIDMPw==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-google-analytics": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz",
+      "integrity": "sha512-xzCjAoKuOb55CBSwQrbyWBKqp35yg1vw9ohIlU2wTy06ZrYfJ8rKochb1MSGlnoBfXGWss3UPzxR5QL5guIFdg==",
+      "dev": true,
+      "requires": {
+        "workbox-background-sync": "^4.3.1",
+        "workbox-core": "^4.3.1",
+        "workbox-routing": "^4.3.1",
+        "workbox-strategies": "^4.3.1"
+      }
+    },
+    "workbox-navigation-preload": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz",
+      "integrity": "sha512-K076n3oFHYp16/C+F8CwrRqD25GitA6Rkd6+qAmLmMv1QHPI2jfDwYqrytOfKfYq42bYtW8Pr21ejZX7GvALOw==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-precaching": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.3.1.tgz",
+      "integrity": "sha512-piSg/2csPoIi/vPpp48t1q5JLYjMkmg5gsXBQkh/QYapCdVwwmKlU9mHdmy52KsDGIjVaqEUMFvEzn2LRaigqQ==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-range-requests": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz",
+      "integrity": "sha512-S+HhL9+iTFypJZ/yQSl/x2Bf5pWnbXdd3j57xnb0V60FW1LVn9LRZkPtneODklzYuFZv7qK6riZ5BNyc0R0jZA==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-routing": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.3.1.tgz",
+      "integrity": "sha512-FkbtrODA4Imsi0p7TW9u9MXuQ5P4pVs1sWHK4dJMMChVROsbEltuE79fBoIk/BCztvOJ7yUpErMKa4z3uQLX+g==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-strategies": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.3.1.tgz",
+      "integrity": "sha512-F/+E57BmVG8dX6dCCopBlkDvvhg/zj6VDs0PigYwSN23L8hseSRwljrceU2WzTvk/+BSYICsWmRq5qHS2UYzhw==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-streams": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.3.1.tgz",
+      "integrity": "sha512-4Kisis1f/y0ihf4l3u/+ndMkJkIT4/6UOacU3A4BwZSAC9pQ9vSvJpIi/WFGQRH/uPXvuVjF5c2RfIPQFSS2uA==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
+    },
+    "workbox-sw": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.3.1.tgz",
+      "integrity": "sha512-0jXdusCL2uC5gM3yYFT6QMBzKfBr2XTk0g5TPAV4y8IZDyVNDyj1a8uSXy3/XrvkVTmQvLN4O5k3JawGReXr9w==",
+      "dev": true
+    },
+    "workbox-window": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-4.3.1.tgz",
+      "integrity": "sha512-C5gWKh6I58w3GeSc0wp2Ne+rqVw8qwcmZnQGpjiek8A2wpbxSJb1FdCoQVO+jDJs35bFgo/WETgl1fqgsxN0Hg==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.3.1"
+      }
     },
     "wrap-ansi": {
       "version": "5.1.0",
@@ -7907,6 +9163,23 @@
           }
         }
       }
+    },
+    "write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
     },
     "xmlbuilder": {
       "version": "9.0.7",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "http-server": "^0.11.1",
     "live-server": "^1.2.1",
     "parallelshell": "^3.0.2",
-    "phantomcss": "^1.6.0"
+    "phantomcss": "^1.6.0",
+    "workbox-cli": "^4.3.1"
   },
   "scripts": {
     "start": "electron-forge start",
@@ -82,7 +83,8 @@
     "lint": "eslint src/",
     "dev": "live-server",
     "test": "parallelshell \"http-server -p 11822 --silent\" \"casperjs test test.js --engine=slimerjs\"",
-    "test-verbose": "parallelshell \"http-server -p 11822\" \"casperjs test test.js --engine=slimerjs --verbose --log-level=debug\""
+    "test-verbose": "parallelshell \"http-server -p 11822\" \"casperjs test test.js --engine=slimerjs --verbose --log-level=debug\"",
+    "generate-sw": "workbox generateSW"
   },
   "repository": {
     "type": "git",

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,3 @@
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => navigator.serviceWorker.register('./sw.js'));
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,877 @@
+/**
+ * Welcome to your Workbox-powered service worker!
+ *
+ * You'll need to register this file in your web app and you should
+ * disable HTTP caching for this file too.
+ * See https://goo.gl/nhQhGp
+ *
+ * The rest of the code is auto-generated. Please don't update this file
+ * directly; instead, make changes to your Workbox build configuration
+ * and re-run your build process.
+ * See https://goo.gl/2aRDsh
+ */
+
+importScripts("https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js");
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+/**
+ * The workboxSW.precacheAndRoute() method efficiently caches and responds to
+ * requests for URLs in the manifest.
+ * See https://goo.gl/S9QRab
+ */
+self.__precacheManifest = [
+  {
+    "url": "favicon.ico",
+    "revision": "41da0d7d1ac65f715955a8ffe0bc4a0f"
+  },
+  {
+    "url": "help/cloud-mask.png",
+    "revision": "c940bfe6c0ea7ba413683d0927aba2d6"
+  },
+  {
+    "url": "help/clouds.jpg",
+    "revision": "dbfc5169220b9ea36f912ca1d72394e4"
+  },
+  {
+    "url": "help/coUA.css",
+    "revision": "5893f43b84552f579df2ed9ed6a20eb9"
+  },
+  {
+    "url": "help/default.html",
+    "revision": "ac345554a35ec8ab73ca50bf2e09e05b"
+  },
+  {
+    "url": "help/flag&clouds.gif",
+    "revision": "8e6d79af1edd2cc4f4e1473a4fc422d0"
+  },
+  {
+    "url": "help/memcopy.html",
+    "revision": "a30dc1a98bdc4b3e126caff4dfa963c7"
+  },
+  {
+    "url": "help/mspaint.hhc",
+    "revision": "e67d1fee11746bc9b54b60858ddf1b3f"
+  },
+  {
+    "url": "help/mspaint.hhk",
+    "revision": "a9d77dc9efdc37bace7d7890ce7ef734"
+  },
+  {
+    "url": "help/nobgcolor.css",
+    "revision": "c053072c8e5d4db6963d179e2f77b42f"
+  },
+  {
+    "url": "help/onestep.gif",
+    "revision": "f02be7bff6a476c3fb3d97a51be832c9"
+  },
+  {
+    "url": "help/p_airb.gif",
+    "revision": "92a1fbc84455668abb00df074309d4bf"
+  },
+  {
+    "url": "help/p_brush.gif",
+    "revision": "73bb66ea2548d3d1229bb87da6d79e46"
+  },
+  {
+    "url": "help/p_curve.gif",
+    "revision": "47609bf261bad798b461e3c5b5fd8b70"
+  },
+  {
+    "url": "help/p_erase.gif",
+    "revision": "606c7c91b114888eb52e7f55141dbbad"
+  },
+  {
+    "url": "help/p_eye.gif",
+    "revision": "c811681492e148ba08474127579054f0"
+  },
+  {
+    "url": "help/p_free.gif",
+    "revision": "ab095441d497f099c5a05fe7893d56b4"
+  },
+  {
+    "url": "help/p_line.gif",
+    "revision": "089742675638df9c980bb483f8dc7dc4"
+  },
+  {
+    "url": "help/p_opaq.gif",
+    "revision": "033c07fa8db2b1d5ecdb63f8a6e99701"
+  },
+  {
+    "url": "help/p_oval.gif",
+    "revision": "17d0903ff30e58cf33e181d9cefa2f77"
+  },
+  {
+    "url": "help/p_paint.gif",
+    "revision": "4e2adbdf36919469d954d074733feb1d"
+  },
+  {
+    "url": "help/p_pencil.gif",
+    "revision": "335f67e5d60e25cf515cbe890e198d7a"
+  },
+  {
+    "url": "help/p_poly.gif",
+    "revision": "83b3bae7dad86ad91ce5bc397d33ebf5"
+  },
+  {
+    "url": "help/p_rect.gif",
+    "revision": "4e6089842ed5b98568501a2571062813"
+  },
+  {
+    "url": "help/p_rrect.gif",
+    "revision": "c93bb126f7e95ee501fdf79467310de2"
+  },
+  {
+    "url": "help/p_sel.gif",
+    "revision": "7371f1de670107f2f27a8800f3210d03"
+  },
+  {
+    "url": "help/p_trans.gif",
+    "revision": "07fdc7a136d5b46fc44dcae0c15c0dc9"
+  },
+  {
+    "url": "help/p_txt.gif",
+    "revision": "2e8e0d2e622b2718fe8ced7b22853c2f"
+  },
+  {
+    "url": "help/paint_airbrush.html",
+    "revision": "b7f410d0ffd37a14e5243b6b814e6928"
+  },
+  {
+    "url": "help/paint_blackwhite.html",
+    "revision": "a43b4af39547d89bacf1b4537d155a75"
+  },
+  {
+    "url": "help/paint_brush.html",
+    "revision": "4f24322057d14e7655f598fe0ca76f66"
+  },
+  {
+    "url": "help/paint_change_color.html",
+    "revision": "4a245829c7303601ddb0b3eba332c3d9"
+  },
+  {
+    "url": "help/paint_change_size.html",
+    "revision": "3a7c8e96374e02212fc4a7bf5260ba58"
+  },
+  {
+    "url": "help/paint_clear_image.html",
+    "revision": "9e77afcb0eee1bf246fddbae5dfe0b7b"
+  },
+  {
+    "url": "help/paint_color_box.html",
+    "revision": "2e28c3a947a2e3541f8540c55015712a"
+  },
+  {
+    "url": "help/paint_curves.html",
+    "revision": "580287c735e4c18d088ed99a05f1c073"
+  },
+  {
+    "url": "help/paint_custom_colors.html",
+    "revision": "02dd38466d373d63dd74de2e017b0de5"
+  },
+  {
+    "url": "help/paint_cutout_copy_move.html",
+    "revision": "ecbc5f1f279c25d79152b81ee3430351"
+  },
+  {
+    "url": "help/paint_cutout_save.html",
+    "revision": "595803f5695c3b685d652a2b602ada96"
+  },
+  {
+    "url": "help/paint_cutout_select.html",
+    "revision": "4489b462349c7ef4dc80eaf69ec091f0"
+  },
+  {
+    "url": "help/paint_enlarge_area.html",
+    "revision": "4b02ae5c2e69ce3be2c66d5793899b40"
+  },
+  {
+    "url": "help/paint_erase_large.html",
+    "revision": "c3ad7d5eda0be26f34ed2f15f0c88234"
+  },
+  {
+    "url": "help/paint_erase_small.html",
+    "revision": "38ed1af00e18adb65c118de8e4983392"
+  },
+  {
+    "url": "help/paint_fill.html",
+    "revision": "3a291587ce6418f2b0bfa27433fa0486"
+  },
+  {
+    "url": "help/paint_flip_picture.html",
+    "revision": "04836e168d00a89f28780cdfc21fd6c0"
+  },
+  {
+    "url": "help/paint_freeform_lines.html",
+    "revision": "e36827abb41760e7e301e7cfb200b22e"
+  },
+  {
+    "url": "help/paint_grid.html",
+    "revision": "1a66b6a942cf8d131a74fb9d0d5ab2d5"
+  },
+  {
+    "url": "help/paint_insert_file.html",
+    "revision": "4897c2a3ff6182351cfd79ff731938e1"
+  },
+  {
+    "url": "help/paint_invert.html",
+    "revision": "6e7841b83958c1a6bd02a808d25bf466"
+  },
+  {
+    "url": "help/paint_lines.html",
+    "revision": "6c5be5ced2db5d8e277801eae206227b"
+  },
+  {
+    "url": "help/paint_not_in_color_box.html",
+    "revision": "3a0b7e23df5164f893bb0f84398ca5c5"
+  },
+  {
+    "url": "help/paint_ovals.html",
+    "revision": "35f3ec3cd350b5869361738231707896"
+  },
+  {
+    "url": "help/paint_polygons.html",
+    "revision": "1aba4c52ec595ecebf665cd43b077685"
+  },
+  {
+    "url": "help/paint_print.html",
+    "revision": "e96a01a2b87351a1b64470e5a22a0dba"
+  },
+  {
+    "url": "help/paint_rectangles.html",
+    "revision": "52e32caa306e04933735dbf9ddc64b29"
+  },
+  {
+    "url": "help/paint_set_default_colors.html",
+    "revision": "2bfcdb915fe4789d492b04d0f6ddef59"
+  },
+  {
+    "url": "help/paint_skew_picture.html",
+    "revision": "e6e4f98deb3daca4e89bac8c552562c4"
+  },
+  {
+    "url": "help/paint_text.html",
+    "revision": "c9eac4acaa58872faa901c40d51ba391"
+  },
+  {
+    "url": "help/paint_toolbox.html",
+    "revision": "7f8bf9ad892703dc57efd66481037402"
+  },
+  {
+    "url": "help/paint_trans_opaque.html",
+    "revision": "973dbd8e38a0744655080f08ee0bf98c"
+  },
+  {
+    "url": "help/paint_undo.html",
+    "revision": "536424a3577ecd33ac1759d2a175d3d3"
+  },
+  {
+    "url": "help/paint_wallpaper.html",
+    "revision": "c0d067b47f71616292dc11904061ea6d"
+  },
+  {
+    "url": "help/paint_zoom.html",
+    "revision": "989e8c2186589d01b71b079b1b22fc27"
+  },
+  {
+    "url": "help/vaporwave.js",
+    "revision": "79912e3c11ff8a37b0793217ab22a708"
+  },
+  {
+    "url": "images/98.js.org.svg",
+    "revision": "fcb179df8b8f7fc6eef56e1780075716"
+  },
+  {
+    "url": "images/arrows.png",
+    "revision": "ddc6440981424885bb932f4c24f8b4ed"
+  },
+  {
+    "url": "images/cursors/airbrush.png",
+    "revision": "40d12cd219d9aba89e70e93c507be3ff"
+  },
+  {
+    "url": "images/cursors/default.png",
+    "revision": "caec2cabbfd1205d88cbeb85d3ba9e67"
+  },
+  {
+    "url": "images/cursors/ew-resize.png",
+    "revision": "1fe49fd87f29f28132fc18a2b5ec265e"
+  },
+  {
+    "url": "images/cursors/eye-dropper.png",
+    "revision": "a969aca27557451d0f239ca460c4a8c8"
+  },
+  {
+    "url": "images/cursors/fill-bucket.png",
+    "revision": "0723f543801c0b13f0e3c4433db247d2"
+  },
+  {
+    "url": "images/cursors/magnifier.png",
+    "revision": "5167678d9d24834c4a55b7849656a2e7"
+  },
+  {
+    "url": "images/cursors/move.png",
+    "revision": "7a5c67912a1f6f3132e076571af4ca28"
+  },
+  {
+    "url": "images/cursors/nesw-resize.png",
+    "revision": "333e66b8ae51c7d06cafeb63f89f9dc1"
+  },
+  {
+    "url": "images/cursors/ns-resize.png",
+    "revision": "b57b960c63007fa85d9a1dacde1dfe0d"
+  },
+  {
+    "url": "images/cursors/nwse-resize.png",
+    "revision": "1f436f3da7a915456a3eb04212827b2f"
+  },
+  {
+    "url": "images/cursors/pencil.png",
+    "revision": "0753abcf4b3b1eb576515a7ef83d17f0"
+  },
+  {
+    "url": "images/cursors/precise-dotted.png",
+    "revision": "a1599b063d8a3dd905e4f72ad45e057e"
+  },
+  {
+    "url": "images/cursors/precise.png",
+    "revision": "694153a0e0c9452fd2dfdf2e3b51758b"
+  },
+  {
+    "url": "images/cursors/precise2.png",
+    "revision": "c2f7ac78a047eb2dc2cd625e41735c29"
+  },
+  {
+    "url": "images/help-icons.png",
+    "revision": "b7bbdf218ec8cea4b18a9c2dfa07591c"
+  },
+  {
+    "url": "images/icons/128x128.png",
+    "revision": "ab4fd1a9957b7ca8c5db3a5b0052a031"
+  },
+  {
+    "url": "images/icons/16x16.png",
+    "revision": "8dc522d480697d00a2566e316244bc92"
+  },
+  {
+    "url": "images/icons/32x32.png",
+    "revision": "ba71b0f7fac1767c2571a00ac183d917"
+  },
+  {
+    "url": "images/icons/48x48.png",
+    "revision": "5c694f244e4e7504cbdb50cd779a504b"
+  },
+  {
+    "url": "images/icons/512x512.png",
+    "revision": "027f92c183c06f98c0e75e8a78ce4798"
+  },
+  {
+    "url": "images/icons/96x96.png",
+    "revision": "769a8daf02c643ae423a807651b453d9"
+  },
+  {
+    "url": "images/icons/android-icon-144x144.png",
+    "revision": "fce7689c2cdb155f942eabaa29617484"
+  },
+  {
+    "url": "images/icons/android-icon-192x192.png",
+    "revision": "689692646eb8e0d0e0de8e7413b6877d"
+  },
+  {
+    "url": "images/icons/android-icon-36x36.png",
+    "revision": "44a9dc92d6fa2db6f0de34519610c38c"
+  },
+  {
+    "url": "images/icons/android-icon-48x48.png",
+    "revision": "5c694f244e4e7504cbdb50cd779a504b"
+  },
+  {
+    "url": "images/icons/android-icon-72x72.png",
+    "revision": "976a650d0bf24553405c173b56ae4806"
+  },
+  {
+    "url": "images/icons/android-icon-96x96.png",
+    "revision": "769a8daf02c643ae423a807651b453d9"
+  },
+  {
+    "url": "images/icons/apple-icon-114x114.png",
+    "revision": "10d7e275ea9412ee85455d5bcdb1db79"
+  },
+  {
+    "url": "images/icons/apple-icon-120x120.png",
+    "revision": "bdf8e605fa0dd490027424ff133e50f1"
+  },
+  {
+    "url": "images/icons/apple-icon-144x144.png",
+    "revision": "fce7689c2cdb155f942eabaa29617484"
+  },
+  {
+    "url": "images/icons/apple-icon-152x152.png",
+    "revision": "5ee64f12817bea35cf9c9c329d4b82c4"
+  },
+  {
+    "url": "images/icons/apple-icon-180x180.png",
+    "revision": "4e76c473fa39051de0bb2daa88e28b39"
+  },
+  {
+    "url": "images/icons/apple-icon-57x57.png",
+    "revision": "37d5b7345a62593fbc071726b057fb5c"
+  },
+  {
+    "url": "images/icons/apple-icon-60x60.png",
+    "revision": "87b07c690c7dd331880c1d6c865beaed"
+  },
+  {
+    "url": "images/icons/apple-icon-72x72.png",
+    "revision": "976a650d0bf24553405c173b56ae4806"
+  },
+  {
+    "url": "images/icons/apple-icon-76x76.png",
+    "revision": "62f927623bb57b8d79003ad21738e5d0"
+  },
+  {
+    "url": "images/icons/apple-icon-precomposed.png",
+    "revision": "72f49ad139b933215f7fbf9fd853503a"
+  },
+  {
+    "url": "images/icons/apple-icon.png",
+    "revision": "72f49ad139b933215f7fbf9fd853503a"
+  },
+  {
+    "url": "images/icons/jspaint.svg",
+    "revision": "757b6fcb7b82be03ddcfb59a7e0cf975"
+  },
+  {
+    "url": "images/icons/mac.icns",
+    "revision": "60a1e86684d75033a6c740b3c2115c2d"
+  },
+  {
+    "url": "images/icons/ms-icon-144x144.png",
+    "revision": "fce7689c2cdb155f942eabaa29617484"
+  },
+  {
+    "url": "images/icons/ms-icon-150x150.png",
+    "revision": "f2c9d9517df802e135b6614fc169adb4"
+  },
+  {
+    "url": "images/icons/ms-icon-310x310.png",
+    "revision": "095df8ece95eaf9d046f502df0ba222e"
+  },
+  {
+    "url": "images/icons/ms-icon-70x70.png",
+    "revision": "b97bae46c184dfaa4db69f341f53383a"
+  },
+  {
+    "url": "images/icons/safari-pinned-tab-source.svg",
+    "revision": "2a88caef1413e9228cf3045a21d72656"
+  },
+  {
+    "url": "images/icons/safari-pinned-tab.svg",
+    "revision": "d99b8290c80f4051026d2b3c30323955"
+  },
+  {
+    "url": "images/icons/silhouette-48x48.svg",
+    "revision": "886d3f719a0250eb0a7b146396e3e24b"
+  },
+  {
+    "url": "images/icons/windows.ico",
+    "revision": "4e21da63ff5c08cb92045fa24d4420aa"
+  },
+  {
+    "url": "images/meta/facebook-card.png",
+    "revision": "b9874ba0251ae62924d9b060fc1d94c7"
+  },
+  {
+    "url": "images/meta/main-screenshot.png",
+    "revision": "3ec3cfd04f41a14f4a0c724425211855"
+  },
+  {
+    "url": "images/meta/mobipaint.png",
+    "revision": "a44bf64b45e77472462d8ced83976886"
+  },
+  {
+    "url": "images/meta/twitter-card.png",
+    "revision": "aa7edbe588e44818d86138a37aa0f091"
+  },
+  {
+    "url": "images/modern/cursors/airbrush-alt.cur",
+    "revision": "98cb0ee7fbc61478f03a25af36e1b575"
+  },
+  {
+    "url": "images/modern/cursors/airbrush.cur",
+    "revision": "98cb0ee7fbc61478f03a25af36e1b575"
+  },
+  {
+    "url": "images/modern/cursors/crosshair-large.cur",
+    "revision": "945dd40360fdffdac51e5a1362d83881"
+  },
+  {
+    "url": "images/modern/cursors/crosshair.cur",
+    "revision": "ec0ab6a9d15d5baadbd075f899d512ab"
+  },
+  {
+    "url": "images/modern/cursors/ew-resize-large.cur",
+    "revision": "a0a5235859e978646c496ec341bdb970"
+  },
+  {
+    "url": "images/modern/cursors/ew-resize.cur",
+    "revision": "5073bbcd9d5a3d2302bbf3fdd59cc040"
+  },
+  {
+    "url": "images/modern/cursors/eye-dropper-large.cur",
+    "revision": "08264d2028602528c0c799c0d4f0d905"
+  },
+  {
+    "url": "images/modern/cursors/eye-dropper.cur",
+    "revision": "6d374405fd033f2622d775b944cf4fb2"
+  },
+  {
+    "url": "images/modern/cursors/magnifier-large.cur",
+    "revision": "a0e107da7163489a0fa175b047eebbf6"
+  },
+  {
+    "url": "images/modern/cursors/magnifier.cur",
+    "revision": "ee224896ef78816cc304ad65cc026e2c"
+  },
+  {
+    "url": "images/modern/cursors/move-large-alt.cur",
+    "revision": "962e90ab223f5ea5d8f2aee17885aa0d"
+  },
+  {
+    "url": "images/modern/cursors/move-large.cur",
+    "revision": "962e90ab223f5ea5d8f2aee17885aa0d"
+  },
+  {
+    "url": "images/modern/cursors/move.cur",
+    "revision": "411d25265a5004c111821f2a2ad0a9d5"
+  },
+  {
+    "url": "images/modern/cursors/nesw-resize-large.cur",
+    "revision": "755331cfa373adc34bce56434a1cd38b"
+  },
+  {
+    "url": "images/modern/cursors/nesw-resize.cur",
+    "revision": "fd930ad80b3a0e3492c3ae77c11719c9"
+  },
+  {
+    "url": "images/modern/cursors/ns-resize-large.cur",
+    "revision": "00681bef313ac95bacae1d654e2d6efd"
+  },
+  {
+    "url": "images/modern/cursors/ns-resize.cur",
+    "revision": "d3883fb2a1c3ff02e13b4fa446df22d3"
+  },
+  {
+    "url": "images/modern/cursors/nwse-resize-large.cur",
+    "revision": "8088a2d89d9924bb3771d3aa81f76e25"
+  },
+  {
+    "url": "images/modern/cursors/nwse-resize.cur",
+    "revision": "bc18e36986e379ab0f87e7d940c5e922"
+  },
+  {
+    "url": "images/modern/cursors/paint-bucket-large.cur",
+    "revision": "02c9ed0fe2caeb817416359a3bd00b77"
+  },
+  {
+    "url": "images/modern/cursors/paint-bucket.cur",
+    "revision": "26d4bef82e8dc53458fc219150ec0222"
+  },
+  {
+    "url": "images/modern/cursors/pencil-large.cur",
+    "revision": "fcfeea664b00ed610159f3017b4a8dc3"
+  },
+  {
+    "url": "images/modern/cursors/pencil.cur",
+    "revision": "65075a7dc27352105a344e01c303e712"
+  },
+  {
+    "url": "images/modern/cursors/precise-large.cur",
+    "revision": "4c3e07d8a18e004516db81deb6edb7fa"
+  },
+  {
+    "url": "images/modern/cursors/precise.cur",
+    "revision": "1d121e1d1a91b7e3dbf6e694b26baa8a"
+  },
+  {
+    "url": "images/modern/cursors/select-alt.cur",
+    "revision": "a53a18ef5d84ba997cf55abaad88f818"
+  },
+  {
+    "url": "images/modern/cursors/select-large-alt.cur",
+    "revision": "5a95dadbba8fb49410a171bae8d38fb9"
+  },
+  {
+    "url": "images/modern/cursors/select-large.cur",
+    "revision": "5a95dadbba8fb49410a171bae8d38fb9"
+  },
+  {
+    "url": "images/modern/cursors/select.cur",
+    "revision": "a53a18ef5d84ba997cf55abaad88f818"
+  },
+  {
+    "url": "images/modern/cursors/text-large.cur",
+    "revision": "3d5b1e905d80bcf4e753155e1ea91c08"
+  },
+  {
+    "url": "images/modern/cursors/text.cur",
+    "revision": "5e8ffb338372410c2025ae282d3dbed5"
+  },
+  {
+    "url": "images/modern/cursors/zoom-in-large.cur",
+    "revision": "e13dfecd83ab243cb0798347a46b7dac"
+  },
+  {
+    "url": "images/modern/cursors/zoom-in.cur",
+    "revision": "e40e7b4c8d21e0f7e4f99697929b14cc"
+  },
+  {
+    "url": "images/modern/cursors/zoom-out-large.cur",
+    "revision": "8feb8883e651471444c27d2a78894637"
+  },
+  {
+    "url": "images/modern/cursors/zoom-out.cur",
+    "revision": "b9ed29883c8407642e7d8127da94b2db"
+  },
+  {
+    "url": "images/modern/options-transparency.png",
+    "revision": "4f0407cbb4119bd1b6ca856fb59ce9af"
+  },
+  {
+    "url": "images/modern/tools-and-stuff.png",
+    "revision": "a5182c761e0b376b8fdc67fb9b59a549"
+  },
+  {
+    "url": "images/modern/tools.png",
+    "revision": "d3a9c577e2a1a21b155872f6ccb49d39"
+  },
+  {
+    "url": "images/options-airbrush-size.png",
+    "revision": "550e985c3ff5d4f80da944595475f520"
+  },
+  {
+    "url": "images/options-magnification.png",
+    "revision": "058aae19f20674d2969c75847c2d9213"
+  },
+  {
+    "url": "images/options-transparency.png",
+    "revision": "b14b9d8487f98e523ed9f903feac65cf"
+  },
+  {
+    "url": "images/text-tools.png",
+    "revision": "b01e35fa9bfe5b4b526a09ec1a2a1f3c"
+  },
+  {
+    "url": "images/toolbar-icons.png",
+    "revision": "e58fe0bca269c727e1ae87c366a47d78"
+  },
+  {
+    "url": "images/tools-and-stuff.png",
+    "revision": "2eb4fe50a6de26db22cc0951055cd1a9"
+  },
+  {
+    "url": "images/transforms/skew-x.png",
+    "revision": "3579a82c61d2f624d3e689e0fb0a336e"
+  },
+  {
+    "url": "images/transforms/skew-y.png",
+    "revision": "83b6821b8a993e8de35220a3852e348f"
+  },
+  {
+    "url": "images/transforms/stretch-x.png",
+    "revision": "ac30e2df0971904e853d9b86e91536cf"
+  },
+  {
+    "url": "images/transforms/stretch-y.png",
+    "revision": "747ed0adbf15ed0103fb90dfe9956f30"
+  },
+  {
+    "url": "index.html",
+    "revision": "cf312effde4fe29b5e1e56061405d957"
+  },
+  {
+    "url": "lib/canvas.toBlob.js",
+    "revision": "f9efe20f507dec380f42afd464b21845"
+  },
+  {
+    "url": "lib/FileSaver.js",
+    "revision": "45c0a77698a49b716c9bd8b24c671ae9"
+  },
+  {
+    "url": "lib/firebase.js",
+    "revision": "5ccfb14e0bcd36764ad6389a35f63fd4"
+  },
+  {
+    "url": "lib/font-detective.js",
+    "revision": "a739e17cc19db7f32c48464b5ef44548"
+  },
+  {
+    "url": "lib/gif.js/gif.js",
+    "revision": "326345913f0fd457bc5a5a47572e62c0"
+  },
+  {
+    "url": "lib/gif.js/gif.worker.js",
+    "revision": "69838c104d724d5e20a578e5301ee818"
+  },
+  {
+    "url": "lib/jquery-3.4.1.min.js",
+    "revision": "220afd743d9e9643852e31a135a9f3ae"
+  },
+  {
+    "url": "lib/konami.js",
+    "revision": "b533736ba12671c53fcac48f6df6e094"
+  },
+  {
+    "url": "lib/libtess.min.js",
+    "revision": "1a8b9f2fb64ae42486db31bdfc96ea8a"
+  },
+  {
+    "url": "lib/palette.js",
+    "revision": "988ab2714549cb42e1367a641cc02eb7"
+  },
+  {
+    "url": "lib/pep.js",
+    "revision": "e5db6a6de593bc0f829e474bf6cdd7dc"
+  },
+  {
+    "url": "src/$ColorBox.js",
+    "revision": "90ce2527c4ad78bc0291e2fe30c349f3"
+  },
+  {
+    "url": "src/$Component.js",
+    "revision": "d370e2d60cf505bab25d9a52d8cd0029"
+  },
+  {
+    "url": "src/$FontBox.js",
+    "revision": "b56080e094773d1033a6bf18db76b81a"
+  },
+  {
+    "url": "src/$Handles.js",
+    "revision": "fca45ee2ee41410fbc693ce6b520980e"
+  },
+  {
+    "url": "src/$MenuBar.js",
+    "revision": "f072ae70a76f3652726c6179aaa6c971"
+  },
+  {
+    "url": "src/$ToolBox.js",
+    "revision": "6ab4fbf7522448042213f184eb1a5385"
+  },
+  {
+    "url": "src/$Window.js",
+    "revision": "7cfc2c53e4d6bf2659879f14c2725ed5"
+  },
+  {
+    "url": "src/app.js",
+    "revision": "db5e15b5d97ad1cc30d5c8e040b5f468"
+  },
+  {
+    "url": "src/canvas-change.js",
+    "revision": "7b4ddd26d91b374ef236e01b5a5bd2e2"
+  },
+  {
+    "url": "src/electron-injected.js",
+    "revision": "a9523aeccadda4d5cb442ec32af0b13c"
+  },
+  {
+    "url": "src/electron-main.js",
+    "revision": "e9438f8972d7753b4d21838419bc48cd"
+  },
+  {
+    "url": "src/extra-tools.js",
+    "revision": "c689519c895f173a8f00888a4b327475"
+  },
+  {
+    "url": "src/functions.js",
+    "revision": "7c4a4665b458d8f613077e679d791f22"
+  },
+  {
+    "url": "src/help.js",
+    "revision": "aaa6542e2532477c0f689d7c71854894"
+  },
+  {
+    "url": "src/helpers.js",
+    "revision": "12f6f698e511d275237ca5988bf6ebe9"
+  },
+  {
+    "url": "src/image-manipulation.js",
+    "revision": "7a372990f17251f13eb348ef20265cf7"
+  },
+  {
+    "url": "src/imgur.js",
+    "revision": "cc9f61eb50a7b3df0fe4db9b7ad4c04b"
+  },
+  {
+    "url": "src/manage-storage.js",
+    "revision": "e9e3c6fe0616bea1ee5a7ea124cf6899"
+  },
+  {
+    "url": "src/menus.js",
+    "revision": "a2397f292b9fce524f277f0b0f98c8ce"
+  },
+  {
+    "url": "src/OnCanvasObject.js",
+    "revision": "28ab355ca7ed8597eb3f1fc60203b558"
+  },
+  {
+    "url": "src/OnCanvasSelection.js",
+    "revision": "aac08c64cd574d056809f2085ef4def9"
+  },
+  {
+    "url": "src/OnCanvasTextBox.js",
+    "revision": "fab4fc10dc906a305892adebb357ae01"
+  },
+  {
+    "url": "src/service-worker.js",
+    "revision": "a0394817eb1249945eeb3ffcfcb6cb36"
+  },
+  {
+    "url": "src/sessions.js",
+    "revision": "efddf06b474bf565a554f8da2e993f96"
+  },
+  {
+    "url": "src/storage.js",
+    "revision": "e1a1f326c20fd5d4b22bb4449da66d95"
+  },
+  {
+    "url": "src/theme.js",
+    "revision": "b4279129cd4af835677b4d4e7c15d1fd"
+  },
+  {
+    "url": "src/tool-options.js",
+    "revision": "a3292e5765a4a4edebc9a31eeeb37830"
+  },
+  {
+    "url": "src/tools.js",
+    "revision": "a0256ad8cad9d7c06180fca9e05e2926"
+  },
+  {
+    "url": "src/vaporwave-fun.js",
+    "revision": "20542371d89ed46baab80a8eb15c558e"
+  },
+  {
+    "url": "styles/layout.css",
+    "revision": "6d6dbef7ae9d3f431dbcb69f7883678d"
+  },
+  {
+    "url": "styles/normalize.css",
+    "revision": "4a2ae678341616b73ff1c8d549d32465"
+  },
+  {
+    "url": "styles/print.css",
+    "revision": "1536af15b5451472d98e65dfcfa3d15e"
+  },
+  {
+    "url": "styles/themes/classic.css",
+    "revision": "fdd8d908bd2e84cd731b14c5e14db8f9"
+  },
+  {
+    "url": "styles/themes/modern.css",
+    "revision": "813a8d8970a2c7789cf3e7b420c92824"
+  }
+].concat(self.__precacheManifest || []);
+workbox.precaching.precacheAndRoute(self.__precacheManifest, {});

--- a/workbox-config.js
+++ b/workbox-config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  "globDirectory": ".",
+  "globPatterns": [
+    "**/*.{png,jpg,css,html,gif,js,svg,icns,ico,cur,hhk,hhc}",
+  ],
+  "globIgnores": [
+    "test.js",
+    "workbox-config.js",
+    "screenshots/**",
+    "node_modules/**"
+  ],
+  "swDest": "sw.js"
+};


### PR DESCRIPTION
This PR adds a Service Worker generated by Workbox. In order to update the service worker implementation, run `npm run generate-sw`.

Closes #109