### PR TITLE
issue 160 fix

### DIFF
--- a/src/tools.js
+++ b/src/tools.js
@@ -990,6 +990,7 @@ tools.forEach((tool)=> {
 			tool.shape_canvas.ctx.clearRect(0, 0, tool.shape_canvas.width, tool.shape_canvas.height);
 			tool.shape_canvas.ctx.fillStyle = ctx.fillStyle;
 			tool.shape_canvas.ctx.strokeStyle = ctx.strokeStyle;
+			tool.shape_canvas.ctx.lineWidth = ctx.lineWidth;
 			tool.shape(tool.shape_canvas.ctx, pointer_start.x, pointer_start.y, pointer.x-pointer_start.x, pointer.y-pointer_start.y);
 		};
 		tool.pointerup = ()=> {


### PR DESCRIPTION
Non-rounded rectangle line width is broken #160 

Fixed this bug. https://github.com/1j01/jspaint/issues/160

Line width was not being set for rectangles so it was defaulting to 1 pixel. Setting the stroke size resolved this issue.