### PR TITLE
fix large square brush

### DIFF
--- a/src/image-manipulation.js
+++ b/src/image-manipulation.js
@@ -161,12 +161,7 @@ const get_circumference_points_for_brush = memoize_synchronous_function((brush_s
 
 	for (let x = 0; x < image_data.width; x += 1) {
 		for (let y = 0; y < image_data.height; y += 1) {
-			if (at(x, y) && (
-				!at(x, y - 1) ||
-				!at(x, y + 1) ||
-				!at(x - 1, y) ||
-				!at(x + 1, y)
-			)) {
+            if (at(x, y)) {
 				points.push({
 					x: x + offset_x,
 					y: y + offset_y,

--- a/src/image-manipulation.js
+++ b/src/image-manipulation.js
@@ -1,11 +1,13 @@
 const fill_threshold = 1; // 1 is just enough for a workaround for Brave browser's farbling: https://github.com/1j01/jspaint/issues/184
 
 function get_brush_canvas_size(brush_size, brush_shape){
-	// brush_shape optional, only matters if it's circle
-	// @TODO: does it actually still matter? the ellipse drawing code has changed
-	
-	// round to nearest even number in order for the canvas to be drawn centered at a point reasonably
-	return Math.ceil(brush_size * (brush_shape === "circle" ? 2.1 : 1) / 2) * 2;
+	switch(brush_shape) {
+		case 'square': // solid shapes need bigger canvas to allow circumference_points() to find all brush edges
+		case 'circle': // bigger canvas also solves odd size circle centering issue
+			return brush_size +1;
+		default:
+			return brush_size;
+	}
 }
 function render_brush(ctx, shape, size){
 	// USAGE NOTE: must be called outside of any other usage of op_canvas (because of draw_ellipse)
@@ -150,7 +152,7 @@ const get_circumference_points_for_brush = memoize_synchronous_function((brush_s
 
 	const brush_canvas = get_brush_canvas(brush_shape, brush_size);
 
-	const image_data = brush_canvas.ctx.getImageData(0, 0, brush_canvas.width + 1, brush_canvas.height);
+	const image_data = brush_canvas.ctx.getImageData(0, 0, brush_canvas.width, brush_canvas.height);
 
 	const at = (x, y)=> image_data.data[(y * image_data.width + x) * 4 + 3] > 0;
 

--- a/src/image-manipulation.js
+++ b/src/image-manipulation.js
@@ -150,7 +150,7 @@ const get_circumference_points_for_brush = memoize_synchronous_function((brush_s
 
 	const brush_canvas = get_brush_canvas(brush_shape, brush_size);
 
-	const image_data = brush_canvas.ctx.getImageData(0, 0, brush_canvas.width, brush_canvas.height);
+	const image_data = brush_canvas.ctx.getImageData(0, 0, brush_canvas.width + 1, brush_canvas.height);
 
 	const at = (x, y)=> image_data.data[(y * image_data.width + x) * 4 + 3] > 0;
 
@@ -161,7 +161,12 @@ const get_circumference_points_for_brush = memoize_synchronous_function((brush_s
 
 	for (let x = 0; x < image_data.width; x += 1) {
 		for (let y = 0; y < image_data.height; y += 1) {
-            if (at(x, y)) {
+			if (at(x, y) && (
+				!at(x, y - 1) ||
+				!at(x, y + 1) ||
+				!at(x - 1, y) ||
+				!at(x + 1, y)
+			)) {
 				points.push({
 					x: x + offset_x,
 					y: y + offset_y,


### PR DESCRIPTION
fixes #163

Hey, I hope I'm not stepping on your toes here. No worries if you have a better fix in mind for this (re your comments on the issue).
I learned a lot about your code just fiddling with this so it won't feel like wasted effort if the fix doesn't work for you.

I will squash the commits before merging but I thought I'd keep them for the review as the progression kinda shows where I'm coming from with this fix.

### Problem
The larges (8pxl) square brush appears hollow when quickly moving horizontally. Other brush shapes and sizes are not affected. Eraser is not affected.

<details><summary>screen shot</summary>

![image](https://user-images.githubusercontent.com/17363771/122699880-1b4f9c80-d1ff-11eb-85d1-51dec0d5aa7b.png)

</details>

### Cause
The bitmap array can not differentiate between 0-1,2 and 7,1. So is identifies the left edge of the square as being adjacent to the right edge of the square.

<details><summary>visualization because this hurt my brain haha</summary>

![image](https://user-images.githubusercontent.com/17363771/122703597-d3347800-d206-11eb-862a-034364b1a509.png)

</details>

So the conditional in the function for finding the circumference (outline) of the brush shape can not be met for values at the left and right edges of the shape.

https://github.com/1j01/jspaint/blob/f7fea8b12d7900d4aaffab3a5875849cb499dbf6/src/image-manipulation.js#L164-L169

<details><summary>screen shot of square brush circumference rendered without  brush stamp</summary>

![image](https://user-images.githubusercontent.com/17363771/122700178-a3ce3d00-d1ff-11eb-8c46-bc482b943801.png)

</details>

This leaves the observable gap in between the filled shape stamps at either end of the line segment.

### Solution

If the canvas is 1 bigger than the brush shape `get_circumference_points_for_brush` can always find the edge of the shape on the canvas.

The best place for increasing the canvas shape seemed to be the function responsible for calculating canvas size based on shape. This increases the canvass shape on both the x and y axis, even though only x would be necessary. I think the minor performance impact is worth the separation of concerns in the code. (Alternative would be to increase the canvas size in the `get_circumference_points_for_brush` function.)

Conveniently this also fixes the issue with rendering odd sized circles. 
I also tested with a custom circle of size 8 and it had the same gap issue as the size 8 square. Handling both sqares and circles the same seems reasonable.

<details><summary>Interrupted circle outline</summary>

![image](https://user-images.githubusercontent.com/17363771/122704176-ff042d80-d207-11eb-8246-06e3d58a6f29.png)

</details>

### QA

Tested all brush shapes and sizes at different speeds and directions. There no longer is a gap.

![image](https://user-images.githubusercontent.com/17363771/122704308-4a1e4080-d208-11eb-8a66-332a37208301.png)

### Performance and Testing

My local set up could be better. I don't have cypress set up yet but will figure that out if the change is desirable and tests are needed.
Performance seems to be same as before change, but my set up is pretty slow so it's hard to tell.