### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts
+
+WORKDIR /app/nestjs
+
+EXPOSE 8080
+
+COPY . /app/nestjs
+
+RUN npm install 
+
+USER 1000
+
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
Added a Dockerfile that can be used for easier building and deployment. For example, we use it to run JSpaint on https://mogenius.com.