### PR TITLE
fix blurriness when display scale factor is > 100%

### DIFF
--- a/src/electron-main.js
+++ b/src/electron-main.js
@@ -3,6 +3,8 @@ const fs = require("fs");
 const path = require("path");
 
 app.enableSandbox();
+app.commandLine.appendSwitch('high-dpi-support', 1);
+app.commandLine.appendSwitch('force-device-scale-factor', 1);
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) { // eslint-disable-line global-require


### PR DESCRIPTION
The electron desktop app was blurry on my windows pc with 125% scaling.

I found a quick fix so I implemented it.