### PR TITLE
Fixes #323

### DIFF
--- a/lib/bmp.js
+++ b/lib/bmp.js
@@ -633,6 +633,7 @@ class BmpDecoder {
 		});
 	}
 	scanImage(padding = 0, width = this.width, processPixel) {
+		this.pos = this.offset;
 		for (let y = this.height - 1; y >= 0; y--) {
 			const line = this.bottomUp ? y : this.height - 1 - y;
 			for (let x = 0; x < width; x++) {


### PR DESCRIPTION
I've set the *cursor* position to the offset parsed from the headers. This seems to solve the problem.

```js
scanImage(padding = 0, width = this.width, processPixel) {
		this.pos = this.offset;
```