### PR TITLE
Fix Stretch/Skew error

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -3571,17 +3571,17 @@ function image_stretch_and_skew() {
 			width: "40px",
 		}).addClass("no-spinner inset-deep");
 		$(E("td")).appendTo($tr).append($img);
-		$(E("td")).appendTo($tr).append($(E("label")).html(render_access_key(label_with_hotkey)).attr("for", input_id));
+		$(E("td")).appendTo($tr).append($(E("label")).html(render_access_key(localize(label_with_hotkey))).attr("for", input_id));
 		$(E("td")).appendTo($tr).append($input);
 		$(E("td")).appendTo($tr).text(label_unit);
 
 		return $input;
 	};
 
-	const stretch_x = $RowInput($fieldset_stretch.find("table"), "stretch-x", localize("&Horizontal:"), 100, "%", 1, 5000);
-	const stretch_y = $RowInput($fieldset_stretch.find("table"), "stretch-y", localize("&Vertical:"), 100, "%", 1, 5000);
-	const skew_x = $RowInput($fieldset_skew.find("table"), "skew-x", localize("H&orizontal:"), 0, localize("Degrees"), -90, 90);
-	const skew_y = $RowInput($fieldset_skew.find("table"), "skew-y", localize("V&ertical:"), 0, localize("Degrees"), -90, 90);
+	const stretch_x = $RowInput($fieldset_stretch.find("table"), "stretch-x", "&Horizontal:", 100, "%", 1, 5000);
+	const stretch_y = $RowInput($fieldset_stretch.find("table"), "stretch-y", "&Vertical:", 100, "%", 1, 5000);
+	const skew_x = $RowInput($fieldset_skew.find("table"), "skew-x", "H&orizontal:", 0, localize("Degrees"), -90, 90);
+	const skew_y = $RowInput($fieldset_skew.find("table"), "skew-y", "V&ertical:", 0, localize("Degrees"), -90, 90);
 
 	$w.$Button(localize("OK"), () => {
 		const x_scale = parseFloat(stretch_x.val()) / 100;


### PR DESCRIPTION
JSPaint reports an error while trying to open "Stretch/Skew" dialog.

![image](https://github.com/user-attachments/assets/c23eeaff-28f2-4bff-b8ff-a3b5ada9bfac)

```
TypeError: Cannot read properties of null (reading 'toUpperCase')
    at $RowInput (https://jspaint.app/src/functions.js:3569:65)
    at image_stretch_and_skew (https://jspaint.app/src/functions.js:3581:20)
    at Object.action (https://jspaint.app/src/menus.js:631:20)
    at item_action (https://jspaint.app/lib/os-gui/MenuBar.js:892:12)
    at HTMLTableRowElement.<anonymous> (https://jspaint.app/lib/os-gui/MenuBar.js:915:7)
    at HTMLTableRowElement.<anonymous> (https://jspaint.app/lib/os-gui/MenuBar.js:909:14)
```


Steps to reproduce the error:

1. Open https://jspaint.app/
2. Make sure not to use English (eg Italian)
3. Click Image - Stretch/Skew
